### PR TITLE
Fix two errors in unit test methods names

### DIFF
--- a/pkg/factories/rune_factory_test.go
+++ b/pkg/factories/rune_factory_test.go
@@ -35,13 +35,13 @@ func TestRunEFactory_KnSourceParams(t *testing.T) {
 	assert.Assert(t, runEFactory.KnSourceFactory().KnSourceParams() != nil)
 }
 
-func KnSourceClientFactory(t *testing.T) {
+func TestKnSourceClientFactory(t *testing.T) {
 	runEFactory := createDefaultRunEFactory()
 
 	assert.Assert(t, runEFactory.KnSourceFactory() != nil)
 }
 
-func KnSourceClient(t *testing.T) {
+func TestKnSourceClient(t *testing.T) {
 	runEFactory := createDefaultRunEFactory()
 
 	knSourceClient, err := runEFactory.KnSourceClient(&cobra.Command{})


### PR DESCRIPTION
I think they are errors. If they are not, just close this PR.