### PR TITLE
Change an interface of RunEFactory to fix an unit test error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/spf13/cobra v0.0.6
 	github.com/spf13/pflag v1.0.5
 	gotest.tools v2.2.0+incompatible
+	k8s.io/api v0.17.0
 	knative.dev/client v0.13.0
+	knative.dev/pkg v0.0.0-20200304185554-312b1be35ceb
 	knative.dev/test-infra v0.0.0-20200320200209-0bc1e8bb1582
 )

--- a/pkg/factories/rune_factory.go
+++ b/pkg/factories/rune_factory.go
@@ -36,19 +36,17 @@ func (f *DefautRunEFactory) KnSourceFactory() types.KnSourceFactory {
 	return f.knSourceFactory
 }
 
-func (f *DefautRunEFactory) KnSourceClient(cmd *cobra.Command) (types.KnSourceClient, error) {
-	knParams := f.knSourceFactory.KnSourceParams().KnParams
-	namespace, err := knParams.GetNamespace(cmd)
-	if err != nil {
-		return nil, err
-	}
-
-	return f.knSourceFactory.CreateKnSourceClient(namespace), nil
+func (f *DefautRunEFactory) KnSourceClient(namespace string) types.KnSourceClient {
+	return f.knSourceFactory.CreateKnSourceClient(namespace)
 }
 
 func (f *DefautRunEFactory) CreateRunE() types.RunE {
 	return func(cmd *cobra.Command, args []string) error {
-		knSourceClient, err := f.KnSourceClient(cmd)
+		namespace, err := f.KnSourceFactory().KnSourceParams().GetNamespace(cmd)
+		if err != nil {
+			return err
+		}
+		knSourceClient := f.KnSourceClient(namespace)
 		if err != nil {
 			return fmt.Errorf("could not access KnSourceClient for command %s", cmd.Name())
 		}
@@ -61,7 +59,11 @@ func (f *DefautRunEFactory) CreateRunE() types.RunE {
 
 func (f *DefautRunEFactory) DeleteRunE() types.RunE {
 	return func(cmd *cobra.Command, args []string) error {
-		knSourceClient, err := f.KnSourceClient(cmd)
+		namespace, err := f.KnSourceFactory().KnSourceParams().GetNamespace(cmd)
+		if err != nil {
+			return err
+		}
+		knSourceClient := f.KnSourceClient(namespace)
 		if err != nil {
 			return fmt.Errorf("could not access KnSourceClient for command %s", cmd.Name())
 		}
@@ -74,7 +76,11 @@ func (f *DefautRunEFactory) DeleteRunE() types.RunE {
 
 func (f *DefautRunEFactory) UpdateRunE() types.RunE {
 	return func(cmd *cobra.Command, args []string) error {
-		knSourceClient, err := f.KnSourceClient(cmd)
+		namespace, err := f.KnSourceFactory().KnSourceParams().GetNamespace(cmd)
+		if err != nil {
+			return err
+		}
+		knSourceClient := f.KnSourceClient(namespace)
 		if err != nil {
 			return fmt.Errorf("could not access KnSourceClient for command %s", cmd.Name())
 		}
@@ -87,7 +93,11 @@ func (f *DefautRunEFactory) UpdateRunE() types.RunE {
 
 func (f *DefautRunEFactory) DescribeRunE() types.RunE {
 	return func(cmd *cobra.Command, args []string) error {
-		knSourceClient, err := f.KnSourceClient(cmd)
+		namespace, err := f.KnSourceFactory().KnSourceParams().GetNamespace(cmd)
+		if err != nil {
+			return err
+		}
+		knSourceClient := f.KnSourceClient(namespace)
 		if err != nil {
 			return fmt.Errorf("could not access KnSourceClient for command %s", cmd.Name())
 		}

--- a/pkg/factories/rune_factory_test.go
+++ b/pkg/factories/rune_factory_test.go
@@ -20,7 +20,6 @@ import (
 	"gotest.tools/assert"
 
 	"github.com/maximilien/kn-source-pkg/pkg/types"
-	"github.com/spf13/cobra"
 )
 
 func TestNewDefaultRunEFactory(t *testing.T) {
@@ -44,9 +43,8 @@ func TestKnSourceClientFactory(t *testing.T) {
 func TestKnSourceClient(t *testing.T) {
 	runEFactory := createDefaultRunEFactory()
 
-	knSourceClient, err := runEFactory.KnSourceClient(&cobra.Command{})
-	assert.NilError(t, err)
-	assert.Assert(t, knSourceClient, nil)
+	knSourceClient := runEFactory.KnSourceClient("fake_namespace")
+	assert.Assert(t, knSourceClient != nil)
 }
 
 func TestCreateRunE(t *testing.T) {

--- a/pkg/types/interfaces.go
+++ b/pkg/types/interfaces.go
@@ -60,5 +60,5 @@ type RunEFactory interface {
 	DescribeRunE() RunE
 
 	KnSourceFactory() KnSourceFactory
-	KnSourceClient(cmd *cobra.Command) (KnSourceClient, error)
+	KnSourceClient(namespace string) KnSourceClient
 }


### PR DESCRIPTION
I change the method signature `KnSourceClient(cmd *cobra.Command) (types.KnSourceClient, error)` to `KnSourceClient(namespace string) types.KnSourceClient` but moving the logic to fetch namespace to RunE function.

The unit test error we met was caused by below command in unit test. 
```
runEFactory.KnSourceClient(&cobra.Command{})
```
While creating a KnSourceClient, a flag `namespace` needs to be fetched from command. The nil pointer error happens when trying to get namespace from an empty command. See below method.
```
func (f *DefautRunEFactory) KnSourceClient(cmd *cobra.Command) (types.KnSourceClient, error) {
	knParams := f.KnSourceParams().KnParams
	namespace, err := knParams.GetNamespace(cmd)
	if err != nil {
		return nil, err
	}

	return f.knSourceClientFactory.CreateKnSourceClient(namespace), nil
}
```
But in deed, we don't need a cobra.Command, we just need a namespace. So I change the interface to make it easier.
